### PR TITLE
Bangumi打格子和豆瓣书影音 支持开始播放/标记为已播放两种触发方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/douban.png",
     "author": "honue",
     "history": {
-      "v1.8": "支持开始播放/标记为已播放两种触发方式，需要在媒体服务器中配置对应的webhook通知"
+      "v1.8": "支持开始播放/播放完成两种触发方式，需要在媒体服务器中配置对应的webhook通知"
     },
     "level": 1
   },
@@ -79,7 +79,7 @@
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
-      "v1.9": "支持开始播放/标记为已播放两种触发方式，需要在媒体服务器中配置对应的webhook通知",
+      "v1.9": "支持开始播放/播放完成两种触发方式，需要在媒体服务器中配置对应的webhook通知",
       "v1.8": "播放最后一集标记为看完",
       "v1.7": "改进番剧识别的准确率",
       "v1.6": "支持单集点格子",

--- a/package.json
+++ b/package.json
@@ -71,11 +71,12 @@
   "BangumiSync": {
     "name": "Bangumi打格子",
     "description": "将你在媒体库上的番剧观看，同步到Bangumi在看状态",
-    "version": "1.8",
+    "version": "1.9",
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg",
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
+      "v1.9": "支持开始播放/标记为已播放两种触发方式，需要在emby中配置对应的通知webhook",
       "v1.8": "播放最后一集标记为看完",
       "v1.7": "改进番剧识别的准确率",
       "v1.6": "支持单集点格子",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,12 @@
   "DouBanWatching": {
     "name": "豆瓣书影音档案",
     "description": "将剧集在看、看完状态同步到豆瓣书影音档案",
-    "version": "1.7",
+    "version": "1.8",
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/douban.png",
     "author": "honue",
+    "history": {
+      "v1.8": "支持开始播放/标记为已播放两种触发方式，需要在媒体服务器中配置对应的webhook通知"
+    },
     "level": 1
   },
   "ShortCut": {
@@ -76,7 +79,7 @@
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
-      "v1.9": "支持开始播放/标记为已播放两种触发方式，需要在emby中配置对应的通知webhook",
+      "v1.9": "支持开始播放/标记为已播放两种触发方式，需要在媒体服务器中配置对应的webhook通知",
       "v1.8": "播放最后一集标记为看完",
       "v1.7": "改进番剧识别的准确率",
       "v1.6": "支持单集点格子",

--- a/plugins/bangumisync/__init__.py
+++ b/plugins/bangumisync/__init__.py
@@ -14,8 +14,6 @@ import datetime
 import time
 
 
-
-
 class BangumiSync(_PluginBase):
     # 插件名称
     plugin_name = "Bangumi打格子"
@@ -84,7 +82,7 @@ class BangumiSync(_PluginBase):
         if not self._on_played:
             play_flag = "playback.start|media.play|PlaybackStart".split('|')
         else:
-            play_flag = "item.markplayed|media.scrobble".split('|')  # for emby and plex
+            play_flag = "item.markplayed|playback.stop|media.scrobble|PlaybackStop".split('|')
         # 根据路径判断是不是番剧
         path = event_info.item_path
         if not self._enable:
@@ -98,6 +96,13 @@ class BangumiSync(_PluginBase):
             """
                 event='playback.pause' channel='emby' item_type='TV' item_name='咒术回战 S1E47 关门' item_id='22646' item_path='/media/cartoon/动漫/咒术回战 (2020)/Season 1/咒术回战 - S01E47 - 第 47 集.mkv' season_id=1 episode_id=47 tmdb_id=None overview='渋谷事変の最終局面に呪術師が集うなかで、脹相は夏油の亡骸に寄生する“黒幕”の正体に気付く。そして、絶体絶命の危機に現れた特級術師・九十九由基。九十九と“黒幕”がそれぞれ語る人類の未来（ネクストステージ...' percentage=2.5705228512861966 ip='127.0.0.1' device_name='Chrome Windows' client='Emby Web' user_name='honue' image_url=None item_favorite=None save_reason=None item_isvirtual=None media_type='Episode'
             """
+            # emby/jellyfin 根据停止播放时的百分比来判断是否播放完成
+            if event_info.event == "playback.stop":
+                if event_info.percentage is None or event_info.percentage < 90:
+                    return
+            elif event_info.event == "PlaybackStop":
+                if event_info.percentage is None or event_info.percentage < 90:
+                    return
             # 标题
             tmdb_id = event_info.tmdb_id
             logger.info(f"匹配播放事件 {event_info.event}: {event_info.item_name}, tmdb id = {tmdb_id}")
@@ -338,7 +343,6 @@ class BangumiSync(_PluginBase):
                                         'props': {
                                             'model': 'on_played',
                                             'label': '播放完成后同步',
-                                            'hint': '此功能仅支持emby和plex',
                                         }
                                     }
                                 ]
@@ -397,7 +401,7 @@ class BangumiSync(_PluginBase):
                                             'type': 'info',
                                             'variant': 'tonal',
                                             'text': 'access-token获取：https://next.bgm.tv/demo/access-token' + '\n' +
-                                                    '需要开启媒体服务器的webhook，event要包括开始播放或标记为已播放（开启播放完成后同步）' + '\n' + 
+                                                    '需要开启媒体服务器的webhook，event要包括开始播放和停止播放' + '\n' + 
                                                     'http://127.0.0.1:3001/api/v1/webhook?token=<API_TOKEN>，<API_TOKEN>默认为moviepilot' + '\n' +
                                                     '感谢@HankunYu的想法'
                                             ,

--- a/plugins/bangumisync/__init__.py
+++ b/plugins/bangumisync/__init__.py
@@ -20,7 +20,7 @@ class BangumiSync(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg"
     # 插件版本
-    plugin_version = "1.8"
+    plugin_version = "1.9"
     # 插件作者
     plugin_author = "honue,happyTonakai"
     # 作者主页
@@ -61,8 +61,8 @@ class BangumiSync(_PluginBase):
     def hook(self, event: Event):
         logger.debug(f"收到webhook事件: {event.event_data}")
         event_info: WebhookEventInfo = event.event_data
-        # 只判断开始播放的TV剧集是不是anime 调试加入暂停
-        play_start = "playback.start|media.play|PlaybackStart".split('|')
+        # 只判断开始播放或被标记为已播放的TV剧集是不是anime 调试加入暂停
+        play_flag = "playback.start|media.play|PlaybackStart|item.markplayed".split('|')
         # 根据路径判断是不是番剧
         path = event_info.item_path
         if not self._enable:
@@ -71,7 +71,7 @@ class BangumiSync(_PluginBase):
             return
 
         if event_info.item_type in ["TV"] and \
-                event_info.event in play_start and \
+                event_info.event in play_flag and \
                 event_info.user_name in self._user.split(','):
             """
                 event='playback.pause' channel='emby' item_type='TV' item_name='咒术回战 S1E47 关门' item_id='22646' item_path='/media/cartoon/动漫/咒术回战 (2020)/Season 1/咒术回战 - S01E47 - 第 47 集.mkv' season_id=1 episode_id=47 tmdb_id=None overview='渋谷事変の最終局面に呪術師が集うなかで、脹相は夏油の亡骸に寄生する“黒幕”の正体に気付く。そして、絶体絶命の危機に現れた特級術師・九十九由基。九十九と“黒幕”がそれぞれ語る人類の未来（ネクストステージ...' percentage=2.5705228512861966 ip='127.0.0.1' device_name='Chrome Windows' client='Emby Web' user_name='honue' image_url=None item_favorite=None save_reason=None item_isvirtual=None media_type='Episode'
@@ -359,7 +359,8 @@ class BangumiSync(_PluginBase):
                                             'type': 'info',
                                             'variant': 'tonal',
                                             'text': 'access-token获取：https://next.bgm.tv/demo/access-token' + '\n' +
-                                                    'emby添加你mp的webhook（event要包括播放）： http://127.0.0.1:3001/api/v1/webhook?token=moviepilot' + '\n' +
+                                                    'emby添加你mp的webhook（event要包括 播放-开始 或 用户-标记为已播放），开始播放即打格子则勾选前者，播放完毕再打格子则勾选后者，二选一即可：' + '\n' + 
+                                                    'http://127.0.0.1:3001/api/v1/webhook?token=<API_TOKEN>，<API_TOKEN>是mp在环境变量 / 配置文件中设置的token，默认为moviepilot' + '\n' +
                                                     '感谢@HankunYu的想法'
                                             ,
                                             'style': 'white-space: pre-line;'

--- a/plugins/doubanwatching/__init__.py
+++ b/plugins/doubanwatching/__init__.py
@@ -18,7 +18,7 @@ class DouBanWatching(_PluginBase):
     # 插件图标
     plugin_icon = "douban.png"
     # 插件版本
-    plugin_version = "1.7"
+    plugin_version = "1.8"
     # 插件作者
     plugin_author = "honue"
     # 作者主页
@@ -51,7 +51,8 @@ class DouBanWatching(_PluginBase):
     @eventmanager.register(EventType.WebhookMessage)
     def sync_log(self, event: Event):
         event_info: WebhookEventInfo = event.event_data
-        play_start = "playback.start|media.play|PlaybackStart".split('|')
+        logger.debug(f"收到webhook事件: {event_info.event}")
+        play_flag = "playback.start|media.play|PlaybackStart|item.markplayed".split('|')
         # 根据媒体文件路径判断是否要同步到影音档案
         path = event_info.item_path
         if not DouBanWatching.exclude_keyword(path=path, keywords=self._exclude).get("ret"):
@@ -59,7 +60,7 @@ class DouBanWatching(_PluginBase):
             return
 
         processed_items: Dict = self.get_data("processed") or {}
-        if event_info.event in play_start and \
+        if event_info.event in play_flag and \
                 event_info.user_name in self._user.split(','):
             """
                 event='playback.pause' channel='emby' item_type='TV' item_name='咒术回战 S1E47 关门' item_id='22646' item_path='/media/cartoon/动漫/咒术回战 (2020)/Season 1/咒术回战 - S01E47 - 第 47 集.mkv' season_id=1 episode_id=47 tmdb_id=None overview='渋谷事変の最終局面に呪術師が集うなかで、脹相は夏油の亡骸に寄生する“黒幕”の正体に気付く。そして、絶体絶命の危機に現れた特級術師・九十九由基。九十九と“黒幕”がそれぞれ語る人類の未来（ネクストステージ...' percentage=2.5705228512861966 ip='127.0.0.1' device_name='Chrome Windows' client='Emby Web' user_name='honue' image_url=None item_favorite=None save_reason=None item_isvirtual=None media_type='Episode'
@@ -265,7 +266,8 @@ class DouBanWatching(_PluginBase):
                                         'props': {
                                             'type': 'info',
                                             'variant': 'tonal',
-                                            'text': '需要开启媒体服务器的webhook，需要浏览器登录豆瓣，将豆瓣的cookie同步到cookiecloud，也可以手动填写cookie，使用cookiecloud的话需要添加保活 https://movie.douban.com/subject/26934346/'
+                                            'text': '需要开启媒体服务器的webhook，event要包括 开始播放 或 标记为已播放，二选一即可\n' + 
+                                                    '需要浏览器登录豆瓣，将豆瓣的cookie同步到cookiecloud，也可以手动填写cookie，使用cookiecloud的话需要添加保活'
                                         }
                                     }
                                 ]


### PR DESCRIPTION
Emby `item.markplayed` 测试通过。
Plex 根据官方文档 https://support.plex.tv/articles/115002267687-webhooks/ 应该是 `media.scrobble` – Media is viewed (played past the 90% mark).
Jellyfin 暂不支持 https://github.com/jellyfin/jellyfin-plugin-webhook/issues/118 ，大概可以通过 `UserDataSaved` 做进一步筛选，不过我没Jellyfin，用户可以打开debug模式看一下webhook的输出。