### PR TITLE
fix: bangumisync - error when tmdb_id is None and is passed to int().

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,12 +93,13 @@
   "BangumiSync": {
     "name": "Bangumi打格子",
     "description": "将你在媒体库上的番剧观看，同步到Bangumi在看状态",
-    "version": "1.8.3",
+    "version": "1.8.4",
     "v2": true,
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg",
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
+      "v1.8.4": "修复当`tmdb_id`为空时同步失败的问题",
       "v1.8.3": "新增`unique_id`匹配模式, 适配剧集组条目匹配",
       "v1.8.2": "尝试解决因tmdb合并季无法匹配条目的问题",
       "v1.8": "播放最后一集标记为看完",


### PR DESCRIPTION
在上个版本中增加了一个`unique_id`来匹配单集的搜索结果，是通过`event_info.tmdb_id`来匹配的，不过我自己这边emby传过来的webhook中，`tmdb_id`从来都是`None`，所以这段时间一直没有生效。

另外把 try - except 放在比较外面的一层，这样有什么问题都可以及时在log中定位到。