### PR TITLE
Fix #120

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,12 +94,13 @@
   "BangumiSync": {
     "name": "Bangumi打格子",
     "description": "将你在媒体库上的番剧观看，同步到Bangumi在看状态",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "v2": true,
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg",
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
+      "v1.9.1": "修复自定义username之后无法识别番剧收藏状态的问题",
       "v1.9.0": "支持通过episode group匹配季信息",
       "v1.8.6": "使用单集原始名称匹配tmdb和bgm信息",
       "v1.8.5": "支持Plex",

--- a/plugins/bangumisync/__init__.py
+++ b/plugins/bangumisync/__init__.py
@@ -20,7 +20,7 @@ class BangumiSync(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg"
     # 插件版本
-    plugin_version = "1.9.0"
+    plugin_version = "1.9.1"
     # 插件作者
     plugin_author = "honue,happyTonakai"
     # 作者主页
@@ -250,7 +250,7 @@ class BangumiSync(_PluginBase):
         # 获取uid
         if not self._bgm_uid:
             resp = self._request.get(url="https://api.bgm.tv/v0/me")
-            self._bgm_uid = resp.json().get("id")
+            self._bgm_uid = resp.json().get("username")
             logger.debug(f"{self._prefix}: 获取到 bgm_uid {self._bgm_uid}")
         else:
             logger.debug(f"{self._prefix}: 使用 bgm_uid {self._bgm_uid}")


### PR DESCRIPTION
bgm有个自定义用户名的功能，如果使用了自定义用户名，API中就不能使用UID来获取 `/v0/users/{username}/collections/{subject_id}` 这个端点了，只能使用username