### PR TITLE
fix(bangumisync): 修复某些情况下错误判断为最终话

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,12 +94,13 @@
   "BangumiSync": {
     "name": "Bangumi打格子",
     "description": "将你在媒体库上的番剧观看，同步到Bangumi在看状态",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "v2": true,
     "icon": "https://raw.githubusercontent.com/honue/MoviePilot-Plugins/main/icons/bangumi.jpg",
     "author": "honue,happyTonakai",
     "level": 2,
     "history": {
+      "v1.9.2": "修复某些情况下错误判断为最终话",
       "v1.9.1": "修复自定义username之后无法识别番剧收藏状态的问题",
       "v1.9.0": "支持通过episode group匹配季信息",
       "v1.8.6": "使用单集原始名称匹配tmdb和bgm信息",


### PR DESCRIPTION
- 当 original_episode_name 匹配成功，但 sort 字段无匹配项时，此时 `info` 的引用为`ep_info[-1]` 导致 `last_episode` 被错误赋值为 `True`，从而将条目错误地标记为`看过`状态

- 采用加权匹配替代现有匹配机制，综合考虑多个匹配因子以提高识别精度